### PR TITLE
Add Tailwind Vite portfolio scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+package-lock.json
+.env

--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
-# codexvite
-Vite Portifolio
+# Utviklerportefølje
+
+Dette er en enkel porteføljeside bygget med Vite og Tailwind CSS.
+
+## Utvikling
+
+```bash
+npm install
+npm run dev
+```
+
+## Bygg
+
+```bash
+npm run build
+```
+
+## Deploy til GitHub Pages
+
+```bash
+npm run deploy
+```

--- a/index.html
+++ b/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="no">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
+    <title>Utviklerportefølje</title>
+  </head>
+  <body class="bg-black text-white font-sans overflow-x-hidden">
+    <div id="loader" class="fixed inset-0 flex items-center justify-center bg-black z-50 transition-opacity duration-500">
+      <svg class="h-16 w-16 text-purple-500 animate-spin" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" class="opacity-25" />
+        <path d="M4 12a8 8 0 018-8" stroke="currentColor" stroke-width="4" class="opacity-75" />
+      </svg>
+    </div>
+    <div id="main" class="hidden opacity-0 translate-x-full transition-all duration-500 ease-snappy" style="will-change: transform, opacity;"></div>
+    <script type="module" src="/src/loader.js"></script>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "dev-portfolio",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "deploy": "gh-pages -d dist"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.4.14",
+    "gh-pages": "^6.0.0",
+    "postcss": "^8.4.21",
+    "tailwindcss": "^3.3.3",
+    "vite": "^5.0.0"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -1,0 +1,7 @@
+export function createFooter() {
+  const footer = document.createElement('footer');
+  footer.className = 'text-center py-8 text-sm text-gray-400 opacity-0 translate-y-8 transition-all duration-500 ease-snappy';
+  footer.style.willChange = 'transform, opacity';
+  footer.innerHTML = `&copy; ${new Date().getFullYear()} Ola Utvikler`;
+  return footer;
+}

--- a/src/components/hero.js
+++ b/src/components/hero.js
@@ -1,0 +1,22 @@
+export function createHero() {
+  const section = document.createElement('section');
+  section.className = 'flex flex-col items-center text-center py-24 gap-6 opacity-0 translate-y-8 transition-all duration-500 ease-snappy';
+  section.style.willChange = 'transform, opacity';
+
+  const h1 = document.createElement('h1');
+  h1.className = 'text-5xl font-bold bg-gradient-to-r from-purple-400 to-pink-600 text-transparent bg-clip-text';
+  h1.textContent = 'Hei, jeg heter Ola Utvikler';
+
+  const p = document.createElement('p');
+  p.className = 'text-xl text-gray-300';
+  p.textContent = 'Frontend-utvikler';
+
+  const btn = document.createElement('a');
+  btn.href = 'https://github.com';
+  btn.target = '_blank';
+  btn.className = 'mt-4 px-6 py-2 bg-purple-600 hover:bg-purple-700 rounded transition transform active:scale-95 focus:outline-none';
+  btn.textContent = 'GitHub';
+
+  section.append(h1, p, btn);
+  return section;
+}

--- a/src/components/nav.js
+++ b/src/components/nav.js
@@ -1,0 +1,25 @@
+export function createNav() {
+  const nav = document.createElement('nav');
+  nav.className = 'w-full flex justify-between items-center py-4 px-8 opacity-0 translate-y-4 transition-all duration-500 ease-snappy';
+  nav.style.willChange = 'transform, opacity';
+
+  const ul = document.createElement('ul');
+  ul.className = 'flex gap-4 text-lg';
+
+  const links = [
+    { href: '#projects', label: 'Prosjekter' },
+    { href: '#about', label: 'Om meg' },
+    { href: '#contact', label: 'Kontakt' }
+  ];
+
+  links.forEach(link => {
+    const a = document.createElement('a');
+    a.href = link.href;
+    a.textContent = link.label;
+    a.className = 'transition hover:text-indigo-400 hover:shadow-lg px-2 py-1 rounded';
+    ul.appendChild(a);
+  });
+
+  nav.appendChild(ul);
+  return nav;
+}

--- a/src/components/sections.js
+++ b/src/components/sections.js
@@ -1,0 +1,41 @@
+export function createProjects() {
+  const section = document.createElement('section');
+  section.id = 'projects';
+  section.className = 'py-16 px-4 opacity-0 translate-y-8 transition-all duration-500 ease-snappy';
+  section.style.willChange = 'transform, opacity';
+  const h2 = document.createElement('h2');
+  h2.className = 'text-3xl mb-4 font-semibold';
+  h2.textContent = 'Prosjekter';
+  const p = document.createElement('p');
+  p.textContent = 'Mine prosjekter kommer her.';
+  section.append(h2, p);
+  return section;
+}
+
+export function createAbout() {
+  const section = document.createElement('section');
+  section.id = 'about';
+  section.className = 'py-16 px-4 opacity-0 translate-y-8 transition-all duration-500 ease-snappy';
+  section.style.willChange = 'transform, opacity';
+  const h2 = document.createElement('h2');
+  h2.className = 'text-3xl mb-4 font-semibold';
+  h2.textContent = 'Om meg';
+  const p = document.createElement('p');
+  p.textContent = 'Kort bio kommer her.';
+  section.append(h2, p);
+  return section;
+}
+
+export function createContact() {
+  const section = document.createElement('section');
+  section.id = 'contact';
+  section.className = 'py-16 px-4 opacity-0 translate-y-8 transition-all duration-500 ease-snappy';
+  section.style.willChange = 'transform, opacity';
+  const h2 = document.createElement('h2');
+  h2.className = 'text-3xl mb-4 font-semibold';
+  h2.textContent = 'Kontakt';
+  const p = document.createElement('p');
+  p.textContent = 'Du kan kontakte meg p\u00e5 e-post.';
+  section.append(h2, p);
+  return section;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,8 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  font-family: 'Inter', sans-serif;
+  @apply scroll-smooth;
+}

--- a/src/loader.js
+++ b/src/loader.js
@@ -1,0 +1,14 @@
+import './index.css'
+
+window.addEventListener('DOMContentLoaded', () => {
+  const loader = document.getElementById('loader');
+  const main = document.getElementById('main');
+  setTimeout(() => {
+    loader.classList.add('opacity-0');
+    loader.addEventListener('transitionend', () => loader.remove());
+    main.classList.remove('hidden');
+    requestAnimationFrame(() => {
+      main.classList.remove('translate-x-full', 'opacity-0');
+    });
+  }, 1500);
+});

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,28 @@
+import './index.css'
+import { createNav } from './components/nav'
+import { createHero } from './components/hero'
+import { createProjects, createAbout, createContact } from './components/sections'
+import { createFooter } from './components/footer'
+
+const app = document.querySelector('#main')
+
+app.append(
+  createNav(),
+  createHero(),
+  createProjects(),
+  createAbout(),
+  createContact(),
+  createFooter()
+)
+
+const revealElements = app.querySelectorAll('nav, section, footer')
+const observer = new IntersectionObserver(entries => {
+  entries.forEach(entry => {
+    if (entry.isIntersecting) {
+      entry.target.classList.remove('opacity-0', 'translate-y-8', 'translate-y-4')
+      observer.unobserve(entry.target)
+    }
+  })
+})
+
+revealElements.forEach(el => observer.observe(el))

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,15 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './index.html',
+    './src/**/*.{js,html}'
+  ],
+  theme: {
+    extend: {
+      transitionTimingFunction: {
+        snappy: 'cubic-bezier(0.25, 1, 0.5, 1)'
+      }
+    },
+  },
+  plugins: [],
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,5 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  base: '/dev-portfolio/'
+})


### PR DESCRIPTION
## Summary
- set up Vite project files manually
- configure Tailwind and PostCSS
- modular JS components for nav, hero, sections, and footer
- initial index.html and styling
- scripts for GitHub Pages deployment
- add loader screen and smooth animation transitions on page reveal
- add `.gitignore` and refine animation easing

## Testing
- `npm install --ignore-scripts --no-audit --no-fund`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687958f84c588332abbeead7d9fb5c54